### PR TITLE
Feature/move logger to contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavelength-js",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Serverless micro-framework and support utilities",
   "main": "src/index.js",
   "directories": {

--- a/src/contrib/errors/aws/apig/index.js
+++ b/src/contrib/errors/aws/apig/index.js
@@ -1,7 +1,7 @@
 /** @module errors */
-const statusCodes = require('../../../utils/http-status-codes');
-const { BaseException } = require('../../../errors');
-const errorCodes = require('../../../errors/error-codes');
+const statusCodes = require('../../../../utils/http-status-codes');
+const { BaseException } = require('../../../../errors');
+const errorCodes = require('../../../../errors/error-codes');
 
 
 class BaseHttpException extends BaseException {

--- a/src/contrib/errors/index.js
+++ b/src/contrib/errors/index.js
@@ -10,11 +10,11 @@ const {
   Base424Exception,
   Base429Exception,
   BaseHttpException,
-} = require('./aws-apig/index');
+} = require('./aws/apig');
 
 
 module.exports = {
-  awsAPIG: {
+  apig: {
     Base4xxException,
     Base5xxException,
     Base401Exception,

--- a/src/contrib/index.js
+++ b/src/contrib/index.js
@@ -1,8 +1,14 @@
 const apigBodyMiddleware = require('./middleware/aws/lambda/event-body-middleware');
 const lambdaWarmupMiddleware = require('./middleware/aws/lambda/warmup-detection-middleware');
 const { apig } = require('./errors');
+const {BufferedCloudWatchLogger} = require('./logging/aws/buffered-cloudwatch-logger')
 
 module.exports = {
+  logging:{
+    aws:{
+      BufferedCloudWatchLogger
+    }
+  },
   middleware: {
     aws: {
       apigBodyMiddleware,

--- a/src/contrib/index.js
+++ b/src/contrib/index.js
@@ -1,6 +1,6 @@
-const apigBodyMiddleware = require('./middleware/aws-lambda/event-body-middleware');
-const lambdaWarmupMiddleware = require('./middleware/aws-lambda/warmup-detection-middleware');
-const { awsAPIG } = require('./errors');
+const apigBodyMiddleware = require('./middleware/aws/lambda/event-body-middleware');
+const lambdaWarmupMiddleware = require('./middleware/aws/lambda/warmup-detection-middleware');
+const { apig } = require('./errors');
 
 module.exports = {
   middleware: {
@@ -10,6 +10,8 @@ module.exports = {
     },
   },
   errors: {
-    awsAPIG,
+    aws: {
+      apig,
+    },
   },
 };

--- a/src/contrib/logging/aws/buffered-cloudwatch-logger.js
+++ b/src/contrib/logging/aws/buffered-cloudwatch-logger.js
@@ -1,0 +1,35 @@
+const StructLog = require('../../../logging');
+const pii = require('../../../utils/pii');
+
+const IGNORED_FIELDS = ['token_use', 'sub', 'locale', 'iat', 'email_verified', 'auth_time', 'aud'];
+
+/**
+ * Formats the interim_desc field and scrubs the cognito authorizer
+ * @param record {Error}
+ * @returns {Error}
+ */
+const details = (record) => {
+  let result = record;
+  if (record) {
+    result = pii.scrubWhitelist(record, 'requestContext.authorizer.claims', IGNORED_FIELDS, 1);
+  }
+
+  return result;
+};
+class BufferedCloudWatchLogger extends StructLog {
+  getLoggerOverrides(options = {}) {
+    return {
+      bindings: {
+        awsLambdaName: options.functionName,
+        awsLambdaRequestId: options.awsRequestId,
+        functionVersion: options.functionVersion,
+      },
+      serializers: {
+        details,
+      },
+    };
+  }
+}
+
+
+module.exports = { BufferedCloudWatchLogger, serializers: { details } };

--- a/src/contrib/logging/aws/buffered-cloudwatch-logger.js
+++ b/src/contrib/logging/aws/buffered-cloudwatch-logger.js
@@ -1,4 +1,4 @@
-const StructLog = require('../../../logging');
+const { StructLog } = require('../../../logging');
 const pii = require('../../../utils/pii');
 
 const IGNORED_FIELDS = ['token_use', 'sub', 'locale', 'iat', 'email_verified', 'auth_time', 'aud'];

--- a/src/contrib/middleware/aws/lambda/event-body-middleware.js
+++ b/src/contrib/middleware/aws/lambda/event-body-middleware.js
@@ -1,4 +1,4 @@
-const { errors } = require('../../../index');
+const { apig: errors } = require('../../../errors');
 
 module.exports = (state) => {
   let result = null;

--- a/src/contrib/middleware/aws/lambda/warmup-detection-middleware.js
+++ b/src/contrib/middleware/aws/lambda/warmup-detection-middleware.js
@@ -1,4 +1,4 @@
-const { CancelExecutionError } = require('../../../errors');
+const { CancelExecutionError } = require('../../../../errors');
 const { get } = require('lodash');
 
 module.exports = (state) => {

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -3,7 +3,11 @@
  * Specific error type to signal execution should immediately stop
  */
 class CancelExecutionError extends Error {
-
+  getResponse() {
+    return {
+      cancelled: true,
+    };
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const { Wavelength } = require('./runtime');
 const { Decay } = require('./runtime/middle-ware');
+const { Container } = require('./runtime/ioc');
 const StructLog = require('./logging');
 const Metrics = require('./logging/inoculators/metrics');
 const { patchConsole, bootstrap } = require('./logging/logger-shim');
@@ -18,6 +19,7 @@ module.exports = {
   StructLog,
   Metrics,
   Wavelength,
+  Container,
   Retry,
   pii,
   contrib,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { Wavelength } = require('./runtime');
 const { Decay } = require('./runtime/middle-ware');
 const { Container } = require('./runtime/ioc');
-const StructLog = require('./logging');
+const { StructLog } = require('./logging');
 const Metrics = require('./logging/inoculators/metrics');
 const { patchConsole, bootstrap } = require('./logging/logger-shim');
 const errors = require('./errors');

--- a/src/logging/buffered-stream.js
+++ b/src/logging/buffered-stream.js
@@ -225,4 +225,4 @@ class BufferedLogStream extends EventEmitter {
   }
 }
 
-module.exports = BufferedLogStream;
+module.exports = { BufferedLogStream };

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -1,8 +1,8 @@
 /** @module slog */
 const bunyan = require('bunyan');
 const serializers = require('./serializers');
-const BufferedLogStream = require('./buffered-stream');
-const LogUtils = require('./logging-utils');
+const { BufferedLogStream } = require('./buffered-stream');
+const { LogUtils } = require('./logging-utils');
 
 /**
  * @class
@@ -12,13 +12,13 @@ class StructLog {
   /**
    * Ctor for Structured Logging class instance
    * @param name {string} Logger name used to override context.functionName
-   * @param context {object} incoming context object
-   * @param filters {[function]} log event filters
+   * @param stream {EventEmitter} incoming context object
    */
-  constructor(name, context, filters = []) {
-    this.name = name || context.functionName;
-    this.stream = new BufferedLogStream(100, filters);
-    this.logger = this.getStructuredLogger(context);
+  constructor(name='Application',
+  stream = new BufferedLogStream(100, []) ) {
+    this.name = name;
+    this.stream = stream;
+    this.logger = this.getStructuredLogger({});
     this.debug = this.getEmitter(bunyan.DEBUG);
     this.info = this.getEmitter(bunyan.INFO);
     this.warn = this.getEmitter(bunyan.WARN);
@@ -34,7 +34,7 @@ class StructLog {
    * @param context {object} incoming AWS lambda context object
    */
   set context(context) {
-    this.logger = this.getStructuredLogger(this.getLoggerOverrides(context));
+    this.logger = this.getStructuredLogger(this.getLoggerOverrides(context || {}));
   }
   /**
    * Helper function to build a log emitter at a given level
@@ -176,4 +176,4 @@ class StructLog {
 }
 
 
-module.exports = StructLog;
+module.exports = { StructLog };

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -12,7 +12,7 @@ class StructLog {
   /**
    * Ctor for Structured Logging class instance
    * @param name {string} Logger name used to override context.functionName
-   * @param context {object} incoming AWS lambda context object
+   * @param context {object} incoming context object
    * @param filters {[function]} log event filters
    */
   constructor(name, context, filters = []) {

--- a/src/logging/logger-shim.js
+++ b/src/logging/logger-shim.js
@@ -5,7 +5,7 @@ const util = require('util');
 const { EventEmitter } = require('events').EventEmitter;
 const _ = require('lodash');
 const bunyan = require('bunyan');
-const StructLog = require('.');
+const { StructLog } = require('.');
 const Metrics = require('./inoculators/metrics');
 const { getStandardResponse } = require('../utils/aws-object-utils');
 const pii = require('../utils/pii');
@@ -25,7 +25,7 @@ class LegacyLogger {
   constructor(name, event, context, filters = []) {
     this.event = event;
     this.context = context;
-    this.logger = new StructLog(name, context, filters);
+    this.logger = new StructLog(name);
     this.logger.info({
       event: 'TRACE',
       bindings: {

--- a/src/logging/logging-utils.js
+++ b/src/logging/logging-utils.js
@@ -59,4 +59,4 @@ class LogUtils {
   }
 }
 
-module.exports = LogUtils;
+module.exports = { LogUtils };

--- a/src/logging/serializers.js
+++ b/src/logging/serializers.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 const bunyan = require('bunyan');
 const pii = require('../utils/pii');
 
-const WHITELIST_ATTRS = ['token_use', 'sub', 'locale', 'iat', 'email_verified', 'auth_time', 'aud'];
 
 module.exports = {
   /**
@@ -27,17 +26,5 @@ module.exports = {
 
     return _.assign({}, err, bunyanError);
   },
-  /**
-   * Formats the interim_desc field and scrubs the cognito authorizer
-   * @param record {Error}
-   * @returns {Error}
-   */
-  interim_desc(record) {
-    let result = record;
-    if (record) {
-      result = pii.scrubWhitelist(record, 'requestContext.authorizer.claims', WHITELIST_ATTRS, 1);
-    }
 
-    return result;
-  },
 };

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -6,7 +6,7 @@ const { getStandardResponse, getStandardError } = require('../utils/aws-object-u
 const pii = require('../utils/pii');
 const {
   Base4xxException, Base5xxException,
-} = require('../contrib/errors/aws-apig');
+} = require('../contrib/errors/aws/apig');
 const {
   CancelExecutionError, BaseException,
 } = require('../errors');

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -157,7 +157,7 @@ class Wavelength {
   checkCancellationError(error) {
     const result = error instanceof CancelExecutionError;
     if (result) {
-      this.state.push({ response: result.getResponse() });
+      this.state.push({ response: error.getResponse() });
     }
     return result;
   }

--- a/src/runtime/ioc.js
+++ b/src/runtime/ioc.js
@@ -1,0 +1,22 @@
+class Container {
+  constructor() {
+    this.resources = {};
+  }
+
+  register(name, resolver) {
+    Object.defineProperty(this, name, {
+      get: () => {
+        this.resources[name] = resolver(this);
+
+        return this.resources[name];
+      },
+      configurable: true,
+      enumerable: true,
+    });
+
+    return this;
+  }
+}
+
+
+module.exports = { Container };

--- a/test/unit/errors/index.unit.test.js
+++ b/test/unit/errors/index.unit.test.js
@@ -1,5 +1,5 @@
 const { errors } = require('../../../src');
-const { errors: { awsAPIG: apiErrors } } = require('../../../src/contrib');
+const { errors: { aws: { apig: apiErrors } } } = require('../../../src/contrib');
 
 const Context = require('../../util/lambda-context-mock');
 

--- a/test/unit/logging/buffered-stream.test.js
+++ b/test/unit/logging/buffered-stream.test.js
@@ -1,5 +1,5 @@
 
-const BufferedLogStream = require('../../../src/logging/buffered-stream');
+const { BufferedLogStream } = require('../../../src/logging/buffered-stream');
 const datas = require('../../testData/scottish-parliment-events.json');
 
 const eventMock = {

--- a/test/unit/logging/logger-shim.unit.test.js
+++ b/test/unit/logging/logger-shim.unit.test.js
@@ -77,7 +77,7 @@ describe('Testing Log Shim', () => {
   });
 
   it('does not emit events < warning until flush is called', () => {
-    patchConsole(null, {}, new Context());
+    patchConsole('test logger', {}, new Context());
     console.info('red', eventMock, { hello: 'world!' });
 
     expect(events.length).toBe(0);
@@ -87,7 +87,7 @@ describe('Testing Log Shim', () => {
 
   it('emits events in the order received', () => {
     process.env.LOG_LEVEL = 'debug';
-    patchConsole(null, {}, new Context());
+    patchConsole('test logger', {}, new Context());
     console.log(1, eventMock, { hello: 'world!' });
     console.log(2, eventMock, { hello: 'world!' });
     console.log(3, eventMock, { hello: 'world!' });
@@ -111,7 +111,7 @@ describe('Testing Log Shim', () => {
   });
 
   it('adds key/vals to subsequent logs after bind', () => {
-    patchConsole(null, {}, new Context());
+    patchConsole('test logger', {}, new Context());
     console.info('red', eventMock, { hello: 'world!' });
     console.bind({ alert: 'RED' });
     console.info('red', eventMock, { hello: 'world!' });

--- a/test/unit/logging/metrics.inoculation.unit.test.js
+++ b/test/unit/logging/metrics.inoculation.unit.test.js
@@ -1,6 +1,6 @@
 const bunyan = require('bunyan');
 const { StructLog, pii, Metrics } = require('../../../src');
-const LogUtils = require('../../../src/logging/logging-utils');
+const { LogUtils } = require('../../../src/logging/logging-utils');
 const Context = require('../../util/lambda-context-mock');
 
 const eventMock = {
@@ -43,7 +43,7 @@ describe('Testing StructLog Metrics', () => {
   });
 
   it('Adds timer to metrics output', async () => {
-    const logger = new StructLog(null, new Context());
+    const logger = new StructLog('test logger');
     logger.inoculate('metrics', new Metrics.MetricsInoculator());
     logger.info({ event: 'red', details: eventMock, bindings: { hello: 'world!' } });
     logger.metrics.timer('testTimer').start();
@@ -68,7 +68,7 @@ describe('Testing StructLog Metrics', () => {
   });
 
   it('Adds counter to metrics output', async () => {
-    const logger = new StructLog(null, new Context());
+    const logger = new StructLog('test logger');
     logger.inoculate('metrics', new Metrics.MetricsInoculator());
     logger.info({ event: 'red', details: eventMock, bindings: { hello: 'world!' } });
     const testCounter = logger.metrics.counter('testCounter');
@@ -94,7 +94,7 @@ describe('Testing StructLog Metrics', () => {
 
 
   it('Adds gauge to metrics output', async () => {
-    const logger = new StructLog(null, new Context());
+    const logger = new StructLog('test logger');
     logger.inoculate('metrics', new Metrics.MetricsInoculator());
     logger.info({ event: 'red', details: eventMock, bindings: { hello: 'world!' } });
     logger.metrics.gauge('testGauge1').update(100);
@@ -115,7 +115,7 @@ describe('Testing StructLog Metrics', () => {
 
 
   it('Adds set to metrics output', async () => {
-    const logger = new StructLog(null, new Context());
+    const logger = new StructLog('test logger');
     logger.inoculate('metrics', new Metrics.MetricsInoculator());
     logger.info({ event: 'red', details: eventMock, bindings: { hello: 'world!' } });
     const testSet = logger.metrics.set('testSet');

--- a/test/unit/logging/metrics.inoculation.unit.test.js
+++ b/test/unit/logging/metrics.inoculation.unit.test.js
@@ -20,13 +20,15 @@ const eventMock = {
 
 
 let events = [];
-const ogDebug = console.debug;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+function logSnoop(...args) {
+  events.push(...args);
+}
 
 describe('Testing StructLog Metrics', () => {
   beforeAll((done) => {
-    console.debug = function debug(...args) {
-      events.push(...args);
-      console.log(...args);
+    process.stdout.write = (chunk, encoding, callback) => {
+      logSnoop(chunk);
     };
     done();
   });
@@ -36,7 +38,7 @@ describe('Testing StructLog Metrics', () => {
     done();
   });
   afterAll((done) => {
-    console.debug = ogDebug;
+    process.stdout.write = originalStdoutWrite;
     done();
   });
 
@@ -123,11 +125,11 @@ describe('Testing StructLog Metrics', () => {
 
     testSet.append(1);
 
-    expect(testSet.format()).toEqual([1,2,'three', 'IV']);
+    expect(testSet.format()).toEqual([1, 2, 'three', 'IV']);
 
     testSet.remove('three');
 
-    expect(testSet.format()).toEqual([1,2, 'IV']);
+    expect(testSet.format()).toEqual([1, 2, 'IV']);
 
     testSet.reset();
     expect(testSet.format()).toEqual([]);

--- a/test/unit/logging/serializers.unit.test.js
+++ b/test/unit/logging/serializers.unit.test.js
@@ -1,6 +1,6 @@
 
 const serializers = require('../../../src/logging/serializers');
-
+const { serializers: { details } } = require('../../../src/contrib/logging/aws/buffered-cloudwatch-logger');
 
 
 describe('Testing Serializers', () => {
@@ -38,7 +38,7 @@ describe('Testing Serializers', () => {
 
   it('checks that pii is removed interim_desc', () => {
     const logEvent = {
-      interim_desc: {
+      details: {
         requestContext: {
           authorizer: {
             claims: {
@@ -51,7 +51,7 @@ describe('Testing Serializers', () => {
         },
       },
     };
-    const result = serializers.interim_desc(logEvent.interim_desc);
+    const result = details(logEvent.details);
 
 
     expect(result.requestContext.authorizer.claims['persisted:']).toBe('*');
@@ -73,7 +73,7 @@ describe('Testing Serializers', () => {
         },
       },
     });
-    const result = serializers.interim_desc(logEvent);
+    const result = details(logEvent);
 
     expect(result.requestContext.authorizer.claims['persisted:']).toBe('*');
     expect(result.requestContext.authorizer.claims['cognito:username:']).toBe('*');
@@ -83,17 +83,15 @@ describe('Testing Serializers', () => {
 
   it('checks that pii removal passes through string', () => {
     const logEvent = 'All your logs are belong to us';
-    const result = serializers.interim_desc(logEvent);
+    const result = details(logEvent);
 
     expect(result).toBe(logEvent);
   });
 
   it('checks that pii removal passes through number', () => {
     const logEvent = 1234567890;
-    const result = serializers.interim_desc(logEvent);
+    const result = details(logEvent);
 
     expect(result).toBe(logEvent);
   });
-
-
 });

--- a/test/unit/runtime/handler-state.unit.test.js
+++ b/test/unit/runtime/handler-state.unit.test.js
@@ -1,5 +1,5 @@
 const Context = require('../../util/lambda-context-mock');
-const StructLog = require('../../../src/logging');
+const { StructLog } = require('../../../src/logging');
 const { HandlerState } = require('../../../src/runtime/handler-state');
 
 function getState(name = 'Test') {

--- a/test/unit/runtime/index.unit.test.js
+++ b/test/unit/runtime/index.unit.test.js
@@ -1,8 +1,8 @@
 
-const { Wavelength, errors, contrib: { middleware: { aws: { lambdaWarmupMiddleware } } } } = require('../../../src');
+const { Wavelength, contrib: { middleware: { aws: { lambdaWarmupMiddleware } } } } = require('../../../src');
 const Context = require('../../util/lambda-context-mock');
 const { createAPIGatewayEvent } = require('../../util/api-gateway-event-mock');
-const { errors: { awsAPIG: apiErrors } } = require('../../../src/contrib');
+const { errors: { aws: { apig: apiErrors } } } = require('../../../src/contrib');
 
 describe('Testing Runtime Engine', () => {
   beforeAll((done) => {

--- a/test/unit/runtime/index.unit.test.js
+++ b/test/unit/runtime/index.unit.test.js
@@ -26,7 +26,7 @@ describe('Testing Runtime Engine', () => {
         Object.assign(state, { requestResult: 200 });
       }]);
 
-    const result = await app.run(async (state) => {
+    const result = await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
     });

--- a/test/unit/runtime/index.unit.test.js
+++ b/test/unit/runtime/index.unit.test.js
@@ -1,9 +1,14 @@
 
-const { Wavelength, contrib: { middleware: { aws: { lambdaWarmupMiddleware } } } } = require('../../../src');
+const { Wavelength, contrib: { middleware: { aws: { lambdaWarmupMiddleware } },
+  logging:{aws: { BufferedCloudWatchLogger }} }, Container, pii } = require('../../../src');
+const { BufferedLogStream }  = require('../../../src/logging/buffered-stream');
 const Context = require('../../util/lambda-context-mock');
 const { createAPIGatewayEvent } = require('../../util/api-gateway-event-mock');
 const { errors: { aws: { apig: apiErrors } } } = require('../../../src/contrib');
 
+const ioc= new Container();
+ioc.register('logger', ioc=> new BufferedCloudWatchLogger('Tester', ioc.logStream));
+ioc.register('logStream', ioc => new BufferedLogStream(100, pii.defaultFilters()));
 describe('Testing Runtime Engine', () => {
   beforeAll((done) => {
     done();
@@ -18,7 +23,7 @@ describe('Testing Runtime Engine', () => {
     const event = createAPIGatewayEvent();
     const contextMock = new Context();
     event.source = 'serverless-plugin-warmup';
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([lambdaWarmupMiddleware,
       function sampleMiddleWare(state) {
@@ -26,11 +31,12 @@ describe('Testing Runtime Engine', () => {
         Object.assign(state, { requestResult: 200 });
       }]);
 
-    const result = await app.handler(async (state) => {
+    const handler = app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
     });
-    expect(result.statusCode).toBe(444);
+    const result = await handler(event, contextMock);
+    expect(result.statusCode).toBe(200);
     const response = JSON.parse(result.body);
     expect(response.cancelled).toBeTruthy();
   });
@@ -38,17 +44,17 @@ describe('Testing Runtime Engine', () => {
     const event = createAPIGatewayEvent();
     const contextMock = new Context();
 
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([function sampleMiddleWare(state) {
       state.logger.info({ bindings: { state, ...{ ware: 1 } } });
       Object.assign(state, { requestResult: 200 });
     }]);
 
-    const result = await app.run(async (state) => {
+    const result = await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
-    });
+    })(event, contextMock);
     expect(JSON.parse(result.body).status).toBe(200);
   });
   it('checks app runs callback style success path', async () => {
@@ -58,26 +64,25 @@ describe('Testing Runtime Engine', () => {
     function callback(err, response) {
       expect(JSON.parse(response.body).status).toBe(200);
     }
-    const app = new Wavelength({
-      name: 'Test API', event, context: contextMock, callback,
-    });
+    const app = new Wavelength('Test API', ioc.logger);
+
 
     app.middleWare.use([function sampleMiddleWare(state) {
       state.logger.info({ bindings: { state, ...{ ware: 1 } } });
       Object.assign(state, { requestResult: 200 });
     }]);
 
-    await app.run(async (state) => {
+    await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
-    });
+    })(event, contextMock, callback);
   });
 
   it('checks propagates async style middleware error correctly', async () => {
     const event = createAPIGatewayEvent();
     const contextMock = new Context();
 
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {
@@ -89,10 +94,10 @@ describe('Testing Runtime Engine', () => {
         return new apiErrors.Base4xxException('Someone set us up the bomb');
       }]);
 
-    const result = await app.run(async (state) => {
+    const result = await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
-    });
+    })(event, contextMock);
     expect(result.statusCode).toBe(400);
     const responseBody = JSON.parse(result.body);
     expect(responseBody.message).toBe('Error: Someone set us up the bomb');
@@ -107,9 +112,8 @@ describe('Testing Runtime Engine', () => {
       const responseBody = JSON.parse(err.body);
       expect(responseBody.message).toBe('Error: Someone set us up the bomb');
     }
-    const app = new Wavelength({
-      name: 'Test API', event, context: contextMock, callback,
-    });
+
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {
@@ -121,10 +125,10 @@ describe('Testing Runtime Engine', () => {
         return new apiErrors.Base4xxException('Someone set us up the bomb');
       }]);
 
-    await app.run(async (state) => {
+    await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { status: state.requestResult };
-    });
+    })(event, contextMock,callback);
   });
 
 
@@ -132,7 +136,7 @@ describe('Testing Runtime Engine', () => {
     const event = createAPIGatewayEvent();
     const contextMock = new Context();
 
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {
@@ -140,10 +144,10 @@ describe('Testing Runtime Engine', () => {
         Object.assign(state, { requestResult: 200 });
       }]);
 
-    const result = await app.run(async (state) => {
+    const result = await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       throw new apiErrors.Base4xxException('Someone set us up the bomb');
-    });
+    })(event, contextMock);
     expect(result.statusCode).toBe(400);
     const responseBody = JSON.parse(result.body);
     expect(responseBody.message).toBe('Error: Someone set us up the bomb');
@@ -158,9 +162,8 @@ describe('Testing Runtime Engine', () => {
       const responseBody = JSON.parse(err.body);
       expect(responseBody.message).toBe('Error: Someone set us up the bomb');
     }
-    const app = new Wavelength({
-      name: 'Test API', event, context: contextMock, callback,
-    });
+
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {
@@ -168,17 +171,17 @@ describe('Testing Runtime Engine', () => {
         Object.assign(state, { requestResult: 200 });
       }]);
 
-    await app.run(async (state) => {
+    await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       throw new apiErrors.Base4xxException('Someone set us up the bomb');
-    });
+    })(event, contextMock, callback);
   });
 
   it('checks status code in state is applied to response', async () => {
     const event = createAPIGatewayEvent();
     const contextMock = new Context();
 
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {
@@ -186,10 +189,10 @@ describe('Testing Runtime Engine', () => {
         Object.assign(state, { status: 201 });
       }]);
 
-    const result = await app.run(async (state) => {
+    const result = await app.handler(async (state) => {
       state.logger.info({ event: 'App handler' });
       return { success: true };
-    });
+    })(event, contextMock);
     expect(result.statusCode).toBe(201);
     expect(JSON.parse(result.body)).toEqual({ success: true });
   });
@@ -199,7 +202,7 @@ describe('Testing Runtime Engine', () => {
     const event = createAPIGatewayEvent({ body: 1234 });
     const contextMock = new Context();
 
-    const app = new Wavelength({ name: 'Test API', event, context: contextMock });
+    const app = new Wavelength('Test API', ioc.logger);
 
     app.middleWare.use([
       function sampleMiddleWare(state) {

--- a/test/unit/runtime/middle-ware.unit.test.js
+++ b/test/unit/runtime/middle-ware.unit.test.js
@@ -2,7 +2,7 @@
 const StructLog = require('../../../src/logging');
 const { HandlerState } = require('../../../src/runtime/handler-state');
 const { Decay } = require('../../../src');
-const { Base422Exception } = require('../../../src/contrib/errors/aws-apig');
+const { Base422Exception } = require('../../../src/contrib/errors/aws/apig');
 const Context = require('../../util/lambda-context-mock');
 
 async function terminal(err, context) {

--- a/test/unit/runtime/middle-ware.unit.test.js
+++ b/test/unit/runtime/middle-ware.unit.test.js
@@ -1,5 +1,5 @@
 
-const StructLog = require('../../../src/logging');
+const { StructLog } = require('../../../src/logging');
 const { HandlerState } = require('../../../src/runtime/handler-state');
 const { Decay } = require('../../../src');
 const { Base422Exception } = require('../../../src/contrib/errors/aws/apig');
@@ -14,7 +14,8 @@ async function terminal(err, context) {
 }
 function getState(name = 'Test') {
   const contextMock = new Context();
-  const logger = new StructLog(name, contextMock);
+  const logger = new StructLog(name);
+  logger.context = contextMock;
   return new HandlerState(name, { req: true }, contextMock, logger);
 }
 describe('Testing Middleware Engine', () => {


### PR DESCRIPTION
# New Pull Request

## Description:
Separates loggers from base and aws specifics over to contrib
Removes support for bulky run type syntax in favor of handler decorator
Added IoC container implementation

## Issue(s) (required):
N/A


## Risk:
NONE

## Dependencies:
NONE